### PR TITLE
Clean up testify suite logic and support nested mode with Bazel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.1.10 - 21 Dec, 2023
+- Updates to fix nested mode when using Bazel, and index all tests under a given path
+
+## v0.1.9 - 6 Oct, 2023
+- Bug fix: Ensure that test explorer cleans up old test case names in Testify suites
+
+## v0.1.8 - 16 Aug, 2023
+- Internal use
+
 ## v0.1.7 - 10 May, 2023
 - Show duplciate extension warning when the user has the regular "Go" extension installed.
 - Bug fixes

--- a/package.json
+++ b/package.json
@@ -380,6 +380,12 @@
         "icon": "$(debug-coverage)"
       },
       {
+        "command": "go.test.getAllChildren",
+        "title": "Resolve All Tests Under this Package",
+        "description": "Resolve all test cases below this path.",
+        "icon": "$(debug-coverage)"
+      },
+      {
         "command": "go.test.generate.package",
         "title": "Go: Generate Unit Tests For Package",
         "description": "Generates unit tests for the current package"
@@ -2897,6 +2903,12 @@
           "command": "go.test.coverage.bazel",
           "when": "testId in go.tests",
           "group": "inline",
+          "icon": "$(debug-coverage)"
+        },
+        {
+          "command": "go.test.getAllChildren",
+          "when": "testId in go.tests",
+          "group": "resolve",
           "icon": "$(debug-coverage)"
         },
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "go-bazel",
   "displayName": "Go with Bazel",
-  "version": "0.39.1-upstream-0.1.7-uber",
+  "version": "0.39.1-upstream-0.1.10-uber",
   "preview": false,
   "publisher": "Uber",
   "description": "Rich Go language support for Visual Studio Code. Supports test and debug with Bazel",

--- a/src/bazel/bazelExplore.ts
+++ b/src/bazel/bazelExplore.ts
@@ -98,7 +98,22 @@ export class BazelGoTestExplorer extends GoTestExplorer {
 				}
 			})
 		);
+		vscode.commands.registerCommand('go.test.getAllChildren', async (item) => {
+			if (!item) {
+				await vscode.window.showErrorMessage('No test selected');
+				return;
+			}
 
+			try {
+				await this.resolver.getAllTestsUnderDirectory(item);
+				this.resolver.updateGoTestContext();
+			} catch (error) {
+				const m = 'Failed to resolve tests';
+				outputChannel.appendLine(`${m}: ${error}`);
+				outputChannel.show();
+				await vscode.window.showErrorMessage(m);
+			}
+		});
 		this.extensionCtx.subscriptions.push(
 			workspace.onDidOpenTextDocument(async (x) => {
 				try {

--- a/src/goTest/resolve.ts
+++ b/src/goTest/resolve.ts
@@ -213,6 +213,7 @@ export class GoTestResolver {
 			await this.processSymbol(doc, item, seen, testify, symbol);
 		}
 
+		if (testify) this.cleanupTestSuites(item, seen);
 		item.children.forEach((child) => {
 			const { name } = GoTest.parseId(child.id);
 			if (!name || !seen.has(name)) {
@@ -491,7 +492,6 @@ export class GoTestResolver {
 
 			const suite = this.getTestSuite(g?.type1 || g?.type2 || variableDef?.groups?.type3 || '');
 			suite.func = item;
-
 			for (const method of suite.methods) {
 				if (!method.parent || GoTest.parseId(method.parent.id).kind !== 'file') {
 					continue;
@@ -515,6 +515,24 @@ export class GoTestResolver {
 			// For multi-line ranges, include the whole first line. Placeholder of 200 characters to capture full line.
 			item.range.isSingleLine ? item.range.end : new vscode.Position(item.range.start.line, 200)
 		);
+	}
+
+	/**
+	 * Clean up a suite by removing test cases that are no longer seen in a given file.
+	 * @param file TestItem representing the file to be checked, since suites can be spread across multiple files.
+	 * @param seen Set of test cases that were seen in the given file during the current update.
+	 */
+	private cleanupTestSuites(file: TestItem, seen: Set<string>) {
+		for (const currentSuite of this.testSuites.values()) {
+			currentSuite.func?.children.forEach((suiteMethod) => {
+				const { name } = GoTest.parseId(suiteMethod.id);
+				// Only dispose of the test case if it is in the same file.
+				// We want to avoid disposing of test cases that were not seen because they are in a different file.
+				if (name && suiteMethod.uri?.fsPath === file.uri?.fsPath && !seen.has(name)) {
+					dispose(this, suiteMethod);
+				}
+			});
+		}
 	}
 }
 

--- a/test/mocks/MockTest.ts
+++ b/test/mocks/MockTest.ts
@@ -225,6 +225,8 @@ export class MockTestWorkspace implements Workspace {
 				doc = new MockTestDocument(uri, unindent(entry.contents), entry.language);
 			} else if (path.basename(uri.path) === 'go.mod') {
 				doc = new MockTestDocument(uri, unindent(entry), 'go.mod');
+			} else if (entry.includes('github.com/stretchr/testify/suite')) {
+				doc = new MockTestDocumentWithSuite(uri, unindent(entry));
 			} else {
 				doc = new MockTestDocument(uri, unindent(entry));
 			}
@@ -254,7 +256,7 @@ export class MockTestWorkspace implements Workspace {
 class MockTestDocument implements TextDocument {
 	constructor(
 		public uri: Uri,
-		private _contents: string,
+		protected _contents: string,
 		public languageId: string = 'go',
 		public isUntitled: boolean = false,
 		public isDirty: boolean = false
@@ -319,5 +321,21 @@ class MockTestDocument implements TextDocument {
 
 	validatePosition(position: Position): Position {
 		throw new Error('Method not implemented.');
+	}
+}
+
+class MockTestDocumentWithSuite extends MockTestDocument {
+	constructor(
+		public uri: Uri,
+		private text: string,
+		public languageId: string = 'go',
+		public isUntitled: boolean = false,
+		public isDirty: boolean = false
+	) {
+		super(uri, text, languageId, isUntitled, isDirty);
+	}
+
+	getText(range?: Range): string {
+		return this._contents;
 	}
 }

--- a/test/testdata/getAllPackagesTest/A/AA/aa1_test.go
+++ b/test/testdata/getAllPackagesTest/A/AA/aa1_test.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestA(t *testing.T) {
+	t.Log("log")
+	t.Errorf("error")
+}

--- a/test/testdata/getAllPackagesTest/A/AA/aa2_test.go
+++ b/test/testdata/getAllPackagesTest/A/AA/aa2_test.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestA(t *testing.T) {
+	t.Log("log")
+	t.Errorf("error")
+}

--- a/test/testdata/getAllPackagesTest/B/b_test.go
+++ b/test/testdata/getAllPackagesTest/B/b_test.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestA(t *testing.T) {
+	t.Log("log")
+	t.Errorf("error")
+}


### PR DESCRIPTION
Adding additional updates to the Uber fork:
- Fix a bug affecting testify suites, where partial test case names were getting added to the test explorer during editing, and old test case names were being left behind after modification of the name.
- Fix nested mode when using Bazel, and allow users to select a part of the tree to index all children beneath
